### PR TITLE
Use RPATH instead of RUNPATH

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,7 +25,7 @@ for i in `ls`; do
                 ln -s ${PREFIX}/${targetsDir}/$j ${PREFIX}/$j
 
                 if [[ $j =~ \.so\. ]]; then
-                    patchelf --set-rpath '$ORIGIN' ${PREFIX}/${targetsDir}/$j
+                    patchelf --set-rpath '$ORIGIN' --force-rpath ${PREFIX}/${targetsDir}/$j
                 fi
             done
         fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 6cd5fc8ae477ea67c6d11f6c9d04fcf382e43378ee774b8a52b94ac68ee68b8c  # [win]
 
 build:
-  number: 0
+  number: 1
   binary_relocation: false
   skip: true  # [osx]
 

--- a/recipe/test-rpath.sh
+++ b/recipe/test-rpath.sh
@@ -11,7 +11,11 @@ for lib in `find ${PREFIX}/${targetsDir}/lib -type f`; do
 
     rpath=$(patchelf --print-rpath $lib)
     echo "$lib rpath: $rpath"
-    [[ $rpath == "\$ORIGIN" ]] || errors+="$lib\n"
+    if [[ $rpath != "\$ORIGIN" ]]; then
+        errors+="$lib\n"
+    elif [[ $(objdump -x ${lib} | grep "PATH") == *"RUNPATH"* ]]; then
+        errors+="$lib\n"
+    fi
 done
 
 if [[ $errors ]]; then


### PR DESCRIPTION
Libraries shipped in conda-forge should specify the RPATH instead of RUNPATH. Addresses conda-forge/cuda-cudart-feedstock#21
