### PR TITLE
Migrate to `{{ stdlib("c") }}`

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -5,9 +5,9 @@ c_compiler_version:
 c_stdlib:
 - sysroot
 c_stdlib_version:
-- '2.12'
+- '2.17'
 cdt_name:
-- cos6
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -2,8 +2,6 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
-c_stdlib_version:
-- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -10,3 +10,7 @@ github:
 provider:
   linux_aarch64: default
   linux_ppc64le: default
+os_version:
+  linux_64: cos7
+  linux_aarch64: cos7
+  linux_ppc64le: cos7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
   sha256: 63101a25268a70380a129c9b05cd5fcfe8cafaf8594b6b358a5e082ce482b679  # [win]
 
 build:
-  number: 1
+  number: 2
   binary_relocation: false
   skip: true  # [osx]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,6 +51,7 @@ outputs:
       build:
         - {{ compiler("c") }}
         - {{ compiler("cxx") }}
+        - {{ stdlib("c") }}
         - arm-variant * {{ arm_variant_type }}  # [aarch64]
         - patchelf <0.18.0                      # [linux]
       host:


### PR DESCRIPTION
The `sysroot*` syntax is getting phased out (https://github.com/conda-forge/conda-forge.github.io/issues/2102).
The recommendation is to move to `{{ stdlib("c") }}`.

Ref https://github.com/conda-forge/cuda-feedstock/issues/26